### PR TITLE
fix(first test case)

### DIFF
--- a/src/__tests__/Transaction.spec.ts
+++ b/src/__tests__/Transaction.spec.ts
@@ -10,9 +10,9 @@ describe('Transaction', () => {
       value: 1200,
     });
 
-    expect(isUuid(response.body.id)).toBe(true);
+    expect(isUuid(response.body.transaction.id)).toBe(true);
 
-    expect(response.body).toMatchObject({
+    expect(response.body.transaction).toMatchObject({
       title: 'Loan',
       type: 'income',
       value: 1200,


### PR DESCRIPTION
Mudanças sugeridas nesse PR:

- Correção de um bug no primeiro teste. Faltou informar o objeto que é esperado dentro do body (transaction), tanto para checar se a id dele é UUid quanto para o teste de matchObject.